### PR TITLE
Add carousel to hero

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/src/App.css
+++ b/src/App.css
@@ -29,3 +29,38 @@ section {
   font-size: 2rem;
   text-decoration: none;
 }
+
+.hero {
+  position: relative;
+  padding: 0;
+}
+
+.hero-carousel {
+  position: relative;
+  overflow: hidden;
+  height: 400px;
+}
+
+.hero-slide {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  opacity: 0;
+  transition: opacity 0.5s ease-in-out;
+}
+
+.hero-slide.active {
+  opacity: 1;
+}
+
+.hero-text {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: #fff;
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.6);
+  text-align: center;
+}

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -1,8 +1,37 @@
+import { useEffect, useState } from 'react'
+
+const images = [
+  'https://images.unsplash.com/photo-1614850523234-3e7ad3c10c91?auto=format&fit=crop&w=800&q=80',
+  'https://images.unsplash.com/photo-1507149833265-60c372daea22?auto=format&fit=crop&w=800&q=80',
+  'https://images.unsplash.com/photo-1558944351-c8c39f6a1d54?auto=format&fit=crop&w=800&q=80'
+]
+
 function Hero() {
+  const [index, setIndex] = useState(0)
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setIndex((i) => (i + 1) % images.length)
+    }, 3000)
+    return () => clearInterval(id)
+  }, [])
+
   return (
     <section className="hero">
-      <h1>Simo</h1>
-      <p>El identificador QR inteligente para mascotas.</p>
+      <div className="hero-carousel">
+        {images.map((src, i) => (
+          <img
+            key={src}
+            src={src}
+            alt="Mascota"
+            className={`hero-slide ${i === index ? 'active' : ''}`}
+          />
+        ))}
+      </div>
+      <div className="hero-text">
+        <h1>Simo</h1>
+        <p>El identificador QR inteligente para mascotas.</p>
+      </div>
     </section>
   )
 }


### PR DESCRIPTION
## Summary
- create `.gitignore` to avoid committing deps
- add simple image carousel to `Hero` component
- style hero slides and overlay text

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6841f71f733483309efce88ad8bdb64a