### PR TITLE
Add Free and Premium pricing plans

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -64,3 +64,37 @@ section {
   text-shadow: 0 2px 4px rgba(0, 0, 0, 0.6);
   text-align: center;
 }
+
+.pricing-cards {
+  display: grid;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.plan {
+  background: #f9f9f9;
+  color: #333;
+  padding: 1.5rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.plan h3 {
+  margin-top: 0;
+}
+
+.plan .price {
+  font-size: 1.5rem;
+  font-weight: bold;
+  margin: 0.5rem 0;
+}
+
+.plan-premium {
+  border: 2px solid #646cff;
+}
+
+@media (min-width: 600px) {
+  .pricing-cards {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}

--- a/src/components/Pricing.jsx
+++ b/src/components/Pricing.jsx
@@ -3,6 +3,26 @@ function Pricing() {
     <section className="pricing">
       <h2>Planes</h2>
       <p>Elige el plan que mejor se adapte a tu mascota.</p>
+      <div className="pricing-cards">
+        <div className="plan">
+          <h3>Free</h3>
+          <p className="price">$0</p>
+          <ul>
+            <li>Registro básico de mascota</li>
+            <li>Generación de QR</li>
+            <li>Soporte por email</li>
+          </ul>
+        </div>
+        <div className="plan plan-premium">
+          <h3>Premium</h3>
+          <p className="price">$10 / mes</p>
+          <ul>
+            <li>Todo lo del plan Free</li>
+            <li>Historial veterinario ilimitado</li>
+            <li>Soporte prioritario</li>
+          </ul>
+        </div>
+      </div>
     </section>
   )
 }


### PR DESCRIPTION
## Summary
- enhance Pricing section with Free and Premium plans
- style pricing cards and make them responsive

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684aeb8213888330930a6952b6bbca75